### PR TITLE
Modify typo error

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Activity | `acli -g activity my-new-activity`
 Fragment | `acli -g fragment my-new-fragment`
 LoginActivity    | `acli -g login-acitivty my-new-login-activity`
 TabbedActivity    | `acli -g tabbed-acitivty my-tabbed-activity`
-FullScreenActivity    | `acli -g tabbed-acitivty my-fullscreen-activity`
-ScrollingActivity    | `acli -g tabbed-acitivty my-scrolling-activity`
+FullScreenActivity    | `acli -g fullscreen-activity my-fullscreen-activity`
+ScrollingActivity    | `acli -g scrolling-acitivty my-scrolling-activity`
 
 If you contribute for other blueprints, please PR to [this repository](https://github.com/endlessdev/android-cli-templates)
 


### PR DESCRIPTION
In original scaffold table,

Scaffold  | Usage
---       | ---
... | ...
FullScreenActivity    | `acli -g tabbed-activity my-fullscreen-activity`
ScrollingActivity    | `acli -g tabbed-acitivty my-scrolling-activity`

So I fix it to correctly scaffold activity.